### PR TITLE
feat(modules): somewhat support offline mode

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -16,6 +16,10 @@ let
   startScript = pkgs.writeScriptBin "start-earth-view" ''
     #!${pkgs.bash}/bin/bash
     file=$(${ev-fetcher}/bin/ev-fetcher $(${pkgs.coreutils}/bin/shuf -n1 ${cfg.imageDirectory}/source.txt) ''${1})
+    if test $? -ne 0; then
+      echo "Error while fetching image"
+      exit 1
+    fi
     ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri file://$file || true
     ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri-dark file://$file || true
     ${pkgs.feh}/bin/feh ${fehFlags} $file

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -17,6 +17,10 @@ let
     ''
       #!${pkgs.bash}/bin/bash
       file=$(${ev-fetcher}/bin/ev-fetcher $(${pkgs.coreutils}/bin/shuf -n1 /etc/earth-view/source.txt) ''${1})
+      if test $? -ne 0; then
+        echo "Error while fetching image"
+        exit 1
+      fi
     ''
   ] ++ optional isGnome ''
     ${pkgs.coreutils}/bin/ln -sf $file /etc/earth-view/current


### PR DESCRIPTION
Currently, if the network is down when the service runs, the fetcher will fail with an error and the background will be set to an invalid path.

This PR fixes that by exiting with a non-zero exit code if the fetcher failed.