### PR TITLE
fix(modules/hm): module path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       forAllSystems = f: nixpkgs.lib.genAttrs systems f;
     in
     {
-      homeManagerModule = import ./modules/home-manager;
+      homeManagerModules.earth-view = import ./modules/home-manager;
       nixosModules = {
         earth-view = import ./modules/nixos;
         default = self.nixosModules.earth-view;


### PR DESCRIPTION
The path to the homeManager Module is wrong. It should have been ` homeManagerModules` instead of ` homeManagerModule` (just like for the nixOS configuration).