### PR TITLE
refactor(modules): deduplicate code

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -35,68 +35,11 @@ let
     ${pkgs.coreutils}/bin/echo "Could not detect environment, use feh"
     ${pkgs.feh}/bin/feh ${fehFlags} $file
   '';
+  opts = import ../options.nix { inherit lib; };
 in
 {
   meta.maintainers = [ lib.maintainers.nicolas-goudry ];
-
-  options = {
-    services.earth-view = {
-      enable = lib.mkEnableOption "" // {
-        description = ''
-          Whether to enable Earth View service.
-
-          Note, if you are using NixOS and have set up a custom
-          desktop manager session for Home Manager, then the session
-          configuration must have the `bgSupport` option set to `true`
-          or the background image set by this module may be
-          overwritten.
-        '';
-      };
-
-      interval = lib.mkOption {
-        type = with lib.types; nullOr str;
-        default = null;
-        example = "1h";
-        description = ''
-          The duration between changing background image. Set to
-          `null` to only set background when logging in. Should be
-          formatted as a duration understood by systemd.
-        '';
-      };
-
-      imageDirectory = lib.mkOption {
-        type = lib.types.str;
-        default = ".earth-view";
-        example = "backgrounds";
-        description = ''
-          The directory to which background images should be
-          downloaded, relative to HOME.
-        '';
-      };
-
-      display = lib.mkOption {
-        type = lib.types.enum [ "center" "fill" "max" "scale" "tile" ];
-        default = "fill";
-        description = ''
-          Display background images according to this option.
-
-          Note that this option has no effect on GNOME shell desktops.
-        '';
-      };
-
-      enableXinerama = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Will place a separate image per screen when enabled,
-          otherwise a single image will be stretched across all
-          screens.
-
-          Note that this option has no effect on GNOME shell desktops.
-        '';
-      };
-    };
-  };
+  options.services.earth-view = opts;
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,41 +1,10 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@args:
 
 let
-  inherit ((pkgs.callPackage ../.. { inherit pkgs; })) earth-view;
-
   cfg = config.services.earth-view;
-
-  fehFlags = lib.concatStringsSep " "
-    ([ "--bg-${cfg.display}" "--no-fehbg" ]
-      ++ lib.optional (!cfg.enableXinerama) "--no-xinerama");
-
-  startScript = pkgs.writeScriptBin "start-earth-view" ''
-    #!${pkgs.bash}/bin/bash
-
-    file=$(${earth-view}/bin/earth-view fetch random -i $HOME/$1/.source -o $HOME/$1)
-
-    if test $? -ne 0; then
-      ${pkgs.coreutils}/bin/echo "Error while fetching image"
-      exit 1
-    fi
-
-    if test "$XDG_CURRENT_DESKTOP" = "GNOME"; then
-      ${pkgs.coreutils}/bin/echo "GNOME detected, use gsettings"
-      ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri file://$file
-      ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri-dark file://$file
-      exit 0
-    fi
-
-    if test "$XDG_CURRENT_DESKTOP" = "KDE"; then
-      ${pkgs.coreutils}/bin/echo "KDE detected, use plasma-apply-wallpaperimage"
-      ${pkgs.libsForQt5.plasma-workspace}/bin/plasma-apply-wallpaperimage $file
-      exit 0
-    fi
-
-    ${pkgs.coreutils}/bin/echo "Could not detect environment, use feh"
-    ${pkgs.feh}/bin/feh ${fehFlags} $file
-  '';
+  mkScript = import ../script.nix args;
   opts = import ../options.nix { inherit lib; };
+  startScript = mkScript "$HOME/${cfg.imageDirectory}";
 in
 {
   meta.maintainers = [ lib.maintainers.nicolas-goudry ];
@@ -62,7 +31,7 @@ in
         Service = {
           Type = "oneshot";
           IOSchedulingClass = "idle";
-          ExecStart = "${startScript}/bin/start-earth-view ${cfg.imageDirectory}";
+          ExecStart = "${startScript}/bin/start";
         };
 
         Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -36,67 +36,11 @@ let
     ${pkgs.coreutils}/bin/echo "Could not detect environment, use feh"
     ${pkgs.feh}/bin/feh ${fehFlags} $file
   '';
+  opts = import ../options.nix { inherit lib; };
 in
 {
   meta.maintainers = [ lib.maintainers.nicolas-goudry ];
-
-  options = {
-    services.earth-view = {
-      enable = lib.mkEnableOption "" // {
-        description = ''
-          Whether to enable Earth View service.
-
-          Note, if you have set up a custom desktop manager session,
-          then the session configuration must have the `bgSupport`
-          option set to `true` or the background image set by this
-          module may be overwritten.
-        '';
-      };
-
-      interval = lib.mkOption {
-        type = with lib.types; nullOr str;
-        default = null;
-        example = "1h";
-        description = ''
-          The duration between changing background image. Set to
-          `null` to only set background when logging in. Should be
-          formatted as a duration understood by systemd.
-        '';
-      };
-
-      imageDirectory = lib.mkOption {
-        type = lib.types.str;
-        default = ".earth-view";
-        example = "backgrounds";
-        description = ''
-          The directory to which background images should be
-          downloaded, relative to HOME.
-        '';
-      };
-
-      display = lib.mkOption {
-        type = lib.types.enum [ "center" "fill" "max" "scale" "tile" ];
-        default = "fill";
-        description = ''
-          Display background images according to this option.
-
-          Note that this option has no effect on GNOME shell desktops.
-        '';
-      };
-
-      enableXinerama = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Will place a separate image per screen when enabled,
-          otherwise a single image will be stretched across all
-          screens.
-
-          Note that this option has no effect on GNOME shell desktops.
-        '';
-      };
-    };
-  };
+  options.services.earth-view = opts;
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,42 +1,10 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@args:
 
 let
-  inherit ((pkgs.callPackage ../.. { inherit pkgs; })) earth-view;
-
   cfg = config.services.earth-view;
-
-  fehFlags = lib.concatStringsSep " "
-    ([ "--bg-${cfg.display}" "--no-fehbg" ]
-      ++ lib.optional (!cfg.enableXinerama) "--no-xinerama");
-
-  startScript = pkgs.writeScriptBin "start-earth-view" ''
-    #!${pkgs.bash}/bin/bash
-
-    mkdir -p $HOME/$1
-    file=$(${earth-view}/bin/earth-view fetch random -i /etc/earth-view/.source -o $HOME/$1)
-
-    if test $? -ne 0; then
-      ${pkgs.coreutils}/bin/echo "Error while fetching image"
-      exit 1
-    fi
-
-    if test "$XDG_CURRENT_DESKTOP" = "GNOME"; then
-      ${pkgs.coreutils}/bin/echo "GNOME detected, use gsettings"
-      ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri file://$file
-      ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri-dark file://$file
-      exit 0
-    fi
-
-    if test "$XDG_CURRENT_DESKTOP" = "KDE"; then
-      ${pkgs.coreutils}/bin/echo "KDE detected, use plasma-apply-wallpaperimage"
-      ${pkgs.libsForQt5.plasma-workspace}/bin/plasma-apply-wallpaperimage $file
-      exit 0
-    fi
-
-    ${pkgs.coreutils}/bin/echo "Could not detect environment, use feh"
-    ${pkgs.feh}/bin/feh ${fehFlags} $file
-  '';
+  mkScript = import ../script.nix args;
   opts = import ../options.nix { inherit lib; };
+  startScript = mkScript "/etc/earth-view/.source";
 in
 {
   meta.maintainers = [ lib.maintainers.nicolas-goudry ];
@@ -63,7 +31,7 @@ in
         serviceConfig = {
           Type = "oneshot";
           IOSchedulingClass = "idle";
-          ExecStart = "${startScript}/bin/start-earth-view ${cfg.imageDirectory}";
+          ExecStart = "${startScript}/bin/start";
         };
 
         wantedBy = [ "graphical-session.target" ];

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,0 +1,57 @@
+{ lib }:
+
+{
+  enable = lib.mkEnableOption "" // {
+    description = ''
+      Whether to enable Earth View service.
+
+      Note, if you have set up a custom desktop manager session,
+      then the session configuration must have the `bgSupport`
+      option set to `true` or the background image set by this
+      module may be overwritten.
+    '';
+  };
+
+  interval = lib.mkOption {
+    type = with lib.types; nullOr str;
+    default = null;
+    example = "1h";
+    description = ''
+      The duration between changing background image. Set to
+      `null` to only set background when logging in. Should be
+      formatted as a duration understood by systemd.
+    '';
+  };
+
+  imageDirectory = lib.mkOption {
+    type = lib.types.str;
+    default = ".earth-view";
+    example = "backgrounds";
+    description = ''
+      The directory to which background images should be
+      downloaded, relative to HOME.
+    '';
+  };
+
+  display = lib.mkOption {
+    type = lib.types.enum [ "center" "fill" "max" "scale" "tile" ];
+    default = "fill";
+    description = ''
+      Display background images according to this option.
+
+      Note that this option has no effect on GNOME shell desktops.
+    '';
+  };
+
+  enableXinerama = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = ''
+      Will place a separate image per screen when enabled,
+      otherwise a single image will be stretched across all
+      screens.
+
+      Note that this option has no effect on GNOME shell desktops.
+    '';
+  };
+}

--- a/modules/script.nix
+++ b/modules/script.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit ((pkgs.callPackage ../. { inherit pkgs; })) earth-view;
+
+  cfg = config.services.earth-view;
+
+  fehFlags = lib.concatStringsSep " "
+    ([ "--bg-${cfg.display}" "--no-fehbg" ]
+      ++ lib.optional (!cfg.enableXinerama) "--no-xinerama");
+in
+source:
+pkgs.writeScriptBin "start" ''
+  #!${pkgs.bash}/bin/bash
+
+  outdir="$HOME/${cfg.imageDirectory}"
+
+  mkdir -p $outdir
+  file=$(${earth-view}/bin/earth-view fetch random -i ${source} -o $outdir)
+
+  if test $? -ne 0; then
+    ${pkgs.coreutils}/bin/echo "Error while fetching image"
+    exit 1
+  fi
+
+  if test "${lib.boolToString cfg.autoUpscale}" = "true"; then
+    upscaled="''${file%.*}@4x.''${file##*.}"
+
+    if ! test -L $upscaled; then
+      if ${pkgs.realesrgan-ncnn-vulkan}/bin/realesrgan-ncnn-vulkan -i $file -o $upscaled -f ext/jpg; then
+        ${pkgs.coreutils}/bin/mv $upscaled $file
+        ${pkgs.coreutils}/bin/ln -s $file $upscaled
+      fi
+    fi
+  fi
+
+  if test "$XDG_CURRENT_DESKTOP" = "GNOME"; then
+    ${pkgs.coreutils}/bin/echo "GNOME detected, use gsettings"
+    ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri file://$file
+    ${pkgs.glib}/bin/gsettings set org.gnome.desktop.background picture-uri-dark file://$file
+    exit 0
+  fi
+
+  if test "$XDG_CURRENT_DESKTOP" = "KDE"; then
+    ${pkgs.coreutils}/bin/echo "KDE detected, use plasma-apply-wallpaperimage"
+    ${pkgs.libsForQt5.plasma-workspace}/bin/plasma-apply-wallpaperimage $file
+    exit 0
+  fi
+
+  ${pkgs.coreutils}/bin/echo "Could not detect environment, use feh"
+  ${pkgs.feh}/bin/feh ${fehFlags} $file
+'';


### PR DESCRIPTION
This PR does not change the inner workings in any way. It simply adds two new files under the `modules` directory:

* `options.nix`: options attrset for modules
* `script.nix`: lambda to generate the start script for the modules

Both NixOS and Home Manager modules now import these files to define their options and startup script.