### PR TITLE
feat(modules): add option to auto start service

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,22 +142,19 @@ Currently supporting:
     imageDirectory = ".earth-view";
     display = "fill";
     enableXinerama = true;
+    autoStart = false;
   };
 }
 ```
 
 > [!TIP]
-> Currently, the systemd service is not automatically started. To manually start it, you can use the following command after applying your configuration:
+> If `autoStart` is set to `false`, the service will only be started on the next login. To set the background after installation you have to manually start the main service:
 >
-> ```shell
-> systemctl --user start earth-view.timer
-> ```
->
-> If that does not work or you would like to manually switch the background you can start/restart the main service:
 > ```shell
 > systemctl --user start earth-view
 > ```
 >
+> This command can also be used to manually switch the background.
 
 ### `enable`
 
@@ -186,6 +183,15 @@ Will place a separate image per screen when enabled, otherwise a single image wi
 
 > [!NOTE]
 > This option has no effect neither on GNOME nor KDE.
+
+### `autoStart`
+
+Whether to start the service automatically, along with its timer when `interval` is set.
+
+> [!NOTE]
+> This feature relies on activation scripts from NixOS (`system.userActivationScripts`) and Home Manager (`home.activation`).
+>
+> However if you are using Home Manager and have the `systemd.user.startServices` option set to anything else than `suggest` or `false`, the module will not define any activation script and will let Home Manager activate the needed services.
 
 ## 🧐 How it works
 

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -54,4 +54,13 @@
       Note that this option has no effect on GNOME shell desktops.
     '';
   };
+
+  autoStart = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Whether to start the service automatically, along with its
+      timer when `interval` is set.
+    '';
+  };
 }

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,8 +1,23 @@
+# Test cases:
+# --------------------------------------------------------------------------------------------------------------------------
+# | enable | interval | autoStart | hmStartServices              | behavior                                                |
+# | ------ | -------- | --------- | ---------------------------- | ------------------------------------------------------- |
+# | false  | N/A      | N/A       | N/A                          | Nothing                                                 |
+# | true   | null     | false     | suggest / false              | Start on login                                          |
+# | true   | null     | false     | legacy  / true / sd-switch   | Start on login                                          |
+# | true   | null     | true      | suggest / false              | Start on login + activation                             |
+# | true   | null     | true      | legacy  / true / sd-switch   | Start on login + activation                             |
+# | true   | "10s"    | false     | suggest / false              | Start on login + each 10s after manual activation       |
+# | true   | "10s"    | false     | legacy  / true / sd-switch   | Start on login + activation + each 10s after activation |
+# | true   | "10s"    | true      | suggest / false              | Start on login + activation + each 10s after activation |
+# | true   | "10s"    | true      | legacy  / true / sd-switch   | Start on login + activation + each 10s after activation |
+# --------------------------------------------------------------------------------------------------------------------------
 { config, lib, pkgs, ... }@args:
 
 let
   cfg = config.services.earth-view;
   common = import ../common args;
+  hmStartServices = config.systemd.user.startServices;
   startScript = common.mkStartScript "$HOME/${cfg.imageDirectory}";
 in
 {
@@ -33,15 +48,57 @@ in
           ExecStart = "${startScript}/bin/start";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = {
+          WantedBy = [
+            "graphical-session.target"
+          ] ++ (
+            if (cfg.autoStart || hmStartServices == "legacy" || hmStartServices)
+            then [ "default.target" ]
+            else [ ]
+          );
+        };
       };
     }
     (lib.mkIf (cfg.interval != null) {
       systemd.user.timers.earth-view = {
         Unit = { Description = "Set random desktop background from Earth View"; };
         Timer = { OnUnitActiveSec = cfg.interval; };
-        Install = { WantedBy = [ "timers.target" ]; };
+
+        Install = {
+          WantedBy = [
+            "timers.target"
+          ] ++ (
+            if cfg.autoStart
+            then [ "default.target" ]
+            else [ ]
+          );
+        };
       };
+    })
+    (lib.mkIf (cfg.autoStart && (hmStartServices == "suggest" || !hmStartServices)) {
+      home.activation.earth-view = lib.hm.dag.entryAfter [ "writeBoundary" ] (
+        lib.concatStringsSep "\n" [
+          ''
+            #!${pkgs.bash}/bin/bash
+
+            dryRun="''${DRY_RUN:-}"
+          ''
+          (if cfg.interval == null then "" else ''
+            if test -n "$dryRun"; then
+              ${pkgs.coreutils}/bin/echo "Would activate earth-view timer through systemctl"
+            else
+              ${pkgs.systemd}/bin/systemctl --user start earth-view.timer
+            fi
+          '')
+          ''
+            if test -n "$dryRun"; then
+              ${pkgs.coreutils}/bin/echo "Would activate earth-view service through systemctl"
+            else
+              ${pkgs.systemd}/bin/systemctl --user start earth-view.service
+            fi
+          ''
+        ]
+      );
     })
   ]);
 }

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,3 +1,13 @@
+# Test cases:
+# -------------------------------------------------------------------------------------------
+# | enable | interval | autoStart | behavior                                                |
+# | ------ | -------- | --------- | ------------------------------------------------------- |
+# | false  | N/A      | N/A       | Nothing                                                 |
+# | true   | null     | false     | Start on login                                          |
+# | true   | null     | true      | Start on login + activation                             |
+# | true   | "10s"    | false     | Start on login + each 10s after manual activation       |
+# | true   | "10s"    | true      | Start on login + activation + each 10s after activation |
+# -------------------------------------------------------------------------------------------
 { config, lib, pkgs, ... }@args:
 
 let
@@ -42,6 +52,12 @@ in
         timerConfig = { OnUnitActiveSec = cfg.interval; };
         wantedBy = [ "timers.target" ];
       };
+    })
+    (lib.mkIf cfg.autoStart {
+      system.userActivationScripts.earthViewAutoStart.text = lib.concatStringsSep "\n" [
+        (if cfg.interval == null then "" else "${pkgs.systemd}/bin/systemctl --user start earth-view.timer")
+        "${pkgs.systemd}/bin/systemctl --user start earth-view.service"
+      ];
     })
   ]);
 }


### PR DESCRIPTION
This PR introduces a new option to the modules: `autoStart`.

When enabled, the modules will define an activation script (`system.userActivationScripts` on NixOS and `home.activation` on Home Manager) to start the main service on configuration activation (`switch` command of `nixos-rebuild` and `home-manager`). The timer service will also be started if the `interval` option is non-null.

Note that the implementation is a little bit different for Home Manager since it already provides an option to start user services: `systemd.user.startServices`. If this option is set to anything else than `suggest` or `false` (which are equivalent), the module will not define any activation script and will let Home Manager activate the needed services.

As a reminder, both modules source file have a table of expected behaviors depending on the given options values in a comment at the beginning of the file. If any changes may touch the startup process later on, all these behaviors should be checked to ensure everything works as expected.