### PR TITLE
refactor(modules): simplify auto start code

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Currently supporting:
 > ```
 >
 > This command can also be used to manually switch the background.
+>
+> Same goes for the timer, if `autoStart` is set to `false`, it will only be started on the next login. To launch the timer after installation you have to manually start it:
+>
+> ```shell
+> systemctl --user start earth-view.timer
+> ```
 
 ### `enable`
 
@@ -193,7 +199,7 @@ Whether to start the service automatically, along with its timer when `interval`
 > [!NOTE]
 > This feature relies on activation scripts from NixOS (`system.userActivationScripts`) and Home Manager (`home.activation`).
 >
-> However if you are using Home Manager and have the `systemd.user.startServices` option set to anything else than `suggest` or `false`, the module will not define any activation script and will let Home Manager activate the needed services.
+> If you are using Home Manager, you may want to use [`systemd.user.startServices`](https://nix-community.github.io/home-manager/options.xhtml#opt-systemd.user.startServices) instead.
 
 ## 🧐 How it works
 

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,23 +1,18 @@
 # Test cases:
-# --------------------------------------------------------------------------------------------------------------------------
-# | enable | interval | autoStart | hmStartServices              | behavior                                                |
-# | ------ | -------- | --------- | ---------------------------- | ------------------------------------------------------- |
-# | false  | N/A      | N/A       | N/A                          | Nothing                                                 |
-# | true   | null     | false     | suggest / false              | Start on login                                          |
-# | true   | null     | false     | legacy  / true / sd-switch   | Start on login                                          |
-# | true   | null     | true      | suggest / false              | Start on login + activation                             |
-# | true   | null     | true      | legacy  / true / sd-switch   | Start on login + activation                             |
-# | true   | "10s"    | false     | suggest / false              | Start on login + each 10s after manual activation       |
-# | true   | "10s"    | false     | legacy  / true / sd-switch   | Start on login + activation + each 10s after activation |
-# | true   | "10s"    | true      | suggest / false              | Start on login + activation + each 10s after activation |
-# | true   | "10s"    | true      | legacy  / true / sd-switch   | Start on login + activation + each 10s after activation |
-# --------------------------------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------
+# | enable | interval | autoStart | behavior                                                |
+# | ------ | -------- | --------- | --------------------------------------------------------|
+# | false  | N/A      | N/A       | Nothing                                                 |
+# | true   | null     | false     | Start on login                                          |
+# | true   | null     | true      | Start on login + activation                             |
+# | true   | "10s"    | false     | Start on login + each 10s after login                   |
+# | true   | "10s"    | true      | Start on login + activation + each 10s after activation |
+# -------------------------------------------------------------------------------------------
 { config, lib, pkgs, ... }@args:
 
 let
   cfg = config.services.earth-view;
   common = import ../common args;
-  hmStartServices = config.systemd.user.startServices;
   startScript = common.mkStartScript "$HOME/${cfg.imageDirectory}/.source";
 in
 {
@@ -48,57 +43,34 @@ in
           ExecStart = "${startScript}/bin/start";
         };
 
-        Install = {
-          WantedBy = [
-            "graphical-session.target"
-          ] ++ (
-            if (cfg.autoStart || hmStartServices == "legacy" || hmStartServices)
-            then [ "default.target" ]
-            else [ ]
-          );
-        };
+        Install.WantedBy = [ "graphical-session.target" ];
       };
     }
     (lib.mkIf (cfg.interval != null) {
       systemd.user.timers.earth-view = {
-        Unit = { Description = "Set random desktop background from Earth View"; };
-        Timer = { OnUnitActiveSec = cfg.interval; };
-
-        Install = {
-          WantedBy = [
-            "timers.target"
-          ] ++ (
-            if cfg.autoStart
-            then [ "default.target" ]
-            else [ ]
-          );
-        };
+        Unit.Description = "Set random desktop background from Earth View";
+        Timer.OnUnitActiveSec = cfg.interval;
+        Install.WantedBy = [ "timers.target" ];
       };
     })
-    (lib.mkIf (cfg.autoStart && (hmStartServices == "suggest" || !hmStartServices)) {
-      home.activation.earth-view = lib.hm.dag.entryAfter [ "writeBoundary" ] (
-        lib.concatStringsSep "\n" [
-          ''
-            #!${pkgs.bash}/bin/bash
+    (lib.mkIf cfg.autoStart {
+      home.activation.earth-view = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        #!${pkgs.bash}/bin/bash
 
-            dryRun="''${DRY_RUN:-}"
-          ''
-          (if cfg.interval == null then "" else ''
-            if test -n "$dryRun"; then
-              ${pkgs.coreutils}/bin/echo "Would activate earth-view timer through systemctl"
-            else
-              ${pkgs.systemd}/bin/systemctl --user start earth-view.timer
-            fi
-          '')
-          ''
-            if test -n "$dryRun"; then
-              ${pkgs.coreutils}/bin/echo "Would activate earth-view service through systemctl"
-            else
-              ${pkgs.systemd}/bin/systemctl --user start earth-view.service
-            fi
-          ''
-        ]
-      );
+        run() {
+          if test -n "''${DRY_RUN:-}"; then
+            ${pkgs.coreutils}/bin/echo "$@"
+          else
+            eval "$@"
+          fi
+        }
+
+        if test -n "${toString cfg.interval}"; then
+          run ${pkgs.systemd}/bin/systemctl --user start earth-view.timer
+        fi
+
+        run ${pkgs.systemd}/bin/systemctl --user start earth-view.service
+      '';
     })
   ]);
 }


### PR DESCRIPTION
This PR simplifies the code related to the `autoStart` option by avoiding to rely on Home Manager `systemd.user.startServices`. It also fixes an issue with the NixOS module where the service timer is not started along with the main service when `autoStart` is disabled.